### PR TITLE
Add basic chunk stream response

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ let run (sock : Lwt_unix.file_descr) =
 ```
 
 ## Todo
-- [ ] Chunked Encoding (**Update**: Works for request bodies now, need to implement serializer for response bodies)
+- [x] Chunked Encoding
 - [ ] 0 copy streaming for bodies
 - [ ] Better error handling
 - [ ] Add docs

--- a/h1-lwt/src/writer.ml
+++ b/h1-lwt/src/writer.ml
@@ -35,6 +35,8 @@ let write_string t msg =
   t.bytes_scheduled <- t.bytes_scheduled + len;
   Bigbuffer.add_string t.buf msg
 
+let writef t fmt = Format.kasprintf (write_string t) fmt
+
 let write_char t msg =
   t.bytes_scheduled <- t.bytes_scheduled + 1;
   Bigbuffer.add_char t.buf msg

--- a/h1-lwt/src/writer.mli
+++ b/h1-lwt/src/writer.mli
@@ -3,6 +3,7 @@ type t
 val create : int -> t
 val write_string : t -> string -> unit
 val write_char : t -> char -> unit
+val writef : t -> ('a, Format.formatter, unit, unit) format4 -> 'a
 val write_bigstring : t -> Bigstringaf.t -> unit
 val write_iovec : t -> Iovec.t -> unit
 val flushed : t -> unit Lwt.t

--- a/h1-types/src/headers.ml
+++ b/h1-types/src/headers.ml
@@ -43,7 +43,7 @@ let find_multi t key =
 
 let get_transfer_encoding headers =
   match List.rev @@ find_multi headers "Transfer-Encoding" with
-  | "chunked" :: _ -> `Chunked
+  | x :: _ when caseless_equal x "chunked" -> `Chunked
   | _x :: _ -> `Bad_request
   | [] -> (
       match


### PR DESCRIPTION
TODO: add better header handling. We should check if user's response
contains proper headers for the transfer encoding we intend to use.