### PR TITLE
don't leave clients waiting for a 100-continue response

### DIFF
--- a/h1-lwt/src/http_server.ml
+++ b/h1-lwt/src/http_server.ml
@@ -107,6 +107,23 @@ let run ~read_buf_size ~write_buf_size ~refill ~write service =
   Io.reader_stream read_buf_size refill
   |> Lstream.through request_stream
   |> Lstream.iter ~f:(fun (req, req_body) ->
+         (* https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1 Http
+            clients can send an Expect: 100-continue header for POST/PUT
+            requests. This indicates that the client wishes to receive a 100
+            (Continue) response before attempting to send (a potentially large)
+            message body.
+
+            TODO: we should allow users to configure what checks should be
+            performed here and provide a way for them to respond with an
+            Expectation failed response to exit early.
+
+            Note: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/417 *)
+         let%lwt () =
+           if Headers.client_waiting_for_100_continue (Request.headers req) then (
+             write_response writer (Response.create `Continue);
+             flush ())
+           else Lwt.return_unit
+         in
          let%lwt res, body = service (req, req_body) in
          write_response writer res;
          let is_chunk = is_chunked_response res in

--- a/h1-types/src/headers.ml
+++ b/h1-types/src/headers.ml
@@ -53,3 +53,9 @@ let get_transfer_encoding headers =
       (* TODO: check for exceptions when converting to int *)
       | [ x ] -> `Fixed (Int64.of_string x)
       | _ -> `Bad_request)
+
+let client_waiting_for_100_continue headers =
+  match find headers "Expect" with
+  | Some x when caseless_equal x "100-continue" -> true
+  | Some _ -> false
+  | None -> false

--- a/h1-types/src/headers.mli
+++ b/h1-types/src/headers.mli
@@ -8,3 +8,4 @@ val iteri : f:(key:string -> data:string -> unit) -> t -> unit
 val find : t -> string -> string option
 val find_multi : t -> string -> string list
 val get_transfer_encoding : t -> [ `Bad_request | `Chunked | `Fixed of int64 ]
+val client_waiting_for_100_continue : t -> bool


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1

Http clients can send an Expect: 100-continue header for POST/PUT
requests. This indicates that the client wishes to receive a 100
(Continue) response before attempting to send (a potentially large)
message body.

TODO: we should allow users to configure what checks should be
performed here and provide a way for them to respond with an
Expectation failed response to exit early.

Note: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/417